### PR TITLE
Adding /etc/ec2_version in ignore list since it contains incorrect build number

### DIFF
--- a/src/distro/distro.py
+++ b/src/distro/distro.py
@@ -153,6 +153,7 @@ _DISTRO_RELEASE_IGNORE_BASENAMES = (
     "plesk-release",
     "iredmail-release",
     "board-release",
+    "ec2_version",
 )
 
 


### PR DESCRIPTION
Adding /etc/ec2_version in ignore list since it contains incorrect build number